### PR TITLE
Debianize the Kivy runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It should be straight forward to use a Raspbian too.
 
 PipaOS is available at http://pipaos.mitako.eu/
 
-The latest features on Kivy 1.9 are [detailed here](http://kivy.org/planet/2015/04/kivy-1-9%C2%A0released/).
+The latest features on Kivy are [detailed here](http://kivy.org/planet/2015/04/kivy-1-9%C2%A0released/).
 
 ### Requirements and preparation
 
@@ -32,10 +32,11 @@ available by running `xsysroot -t`. If it complains, install the suggested packa
 
 ### Building KivyPie
 
-The build process is separated in 2 parts. 
+The build process is separated in 3 stages.
 
  * `build-kivypie.py` is responsible for preparing the OS, install Kivy, and give you a bootable image
  * `install-kivy.sh` The KivyPie build and installation script
+ * `debian_kivypie.py` Extracts Kivy runtime into debian packages for Python 2 and 3.
 
 Execute `build.sh` to build KivyPie from scratch. Follow the progress via the logfile with `tail -f build.log`.
 
@@ -46,6 +47,13 @@ The latest version of KivyPie and additional info can be found at http://kivypie
 
 ###Build debian packages
 
-TODO: Explain how to build them
+You can regenerate debian packages manually from the host, as below:
+
+```
+$ xsysroot -p kivypie -m
+$ python debian_kivypie.py $(xsysroot -q sysroot)
+```
+
+Packages will be available inside the `pkgs` folder.
 
 Enjoy!

--- a/README.md
+++ b/README.md
@@ -44,4 +44,8 @@ Make sure you do `sudo umount /tmp` to use the full sd card available space to b
 
 The latest version of KivyPie and additional info can be found at http://kivypie.mitako.eu
 
+###Build debian packages
+
+TODO: Explain how to build them
+
 Enjoy!

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,23 @@
 #
 #  Builds KivyPie from scratch, then runs basic tests.
 #
+#  TODO: unify xsysroot profile name, it is spread around
+#
 
 logfile=build.log
+xprofile="kivypie"
 
 echo "Building KivyPie - follow progress at $logfile..."
 python -u build_kivypie.py --build-all > $logfile 2>&1
 ./test_image.sh >> $logfile 2>&1
+
+if [ "$?" == "0" ]; then
+    mounted=`xsysroot -p $xprofile -m`
+    if [ "$?" != "0" ]; then
+	echo "Error debianizing - Kivypie profile not found"
+	exit 1
+    else
+	echo "Debianizing Kivypie..."
+	python debian_kivypie.py $(xsysroot -q sysroot)
+    fi
+fi

--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,5 @@
 logfile=build.log
 
 echo "Building KivyPie - follow progress at $logfile..."
-python -u build-kivypie.py --build-all > $logfile 2>&1
+python -u build_kivypie.py --build-all > $logfile 2>&1
 ./test_image.sh >> $logfile 2>&1

--- a/build_kivypie.py
+++ b/build_kivypie.py
@@ -31,30 +31,13 @@
 import os
 import sys
 import time
+import xsysroot
 
 # Release version of KivyPie
-__version__='0.9'
+__version__='1.0'
 
 # Kivy source release branch to build - latest as of today: 1.9.0
 __kivy_github_version__='master'
-
-
-def import_xsysroot():
-    '''
-    Find path to XSysroot and import it
-    You need to create a symlink xsysroot.py -> xsysroot
-    '''
-    which_xsysroot=os.popen('which xsysroot').read().strip()
-    if not which_xsysroot:
-        print 'Could not find xsysroot tool'
-        print 'Please install from https://github.com/skarbat/xsysroot'
-        return None
-    else:
-        print 'xsysroot found at: {}'.format(which_xsysroot)
-        sys.path.append(os.path.dirname(which_xsysroot))
-        import xsysroot
-        return xsysroot
-
 
 
 if __name__ == '__main__':
@@ -79,11 +62,6 @@ if __name__ == '__main__':
             sys.exit(1)
     else:
         print 'Please specify mode: {}'.format(cmd_options)
-        sys.exit(1)
-
-    # import the xsysroot module
-    xsysroot=import_xsysroot()
-    if not xsysroot:
         sys.exit(1)
 
     # Find and activate the xsysroot profile

--- a/debian_kivypie.py
+++ b/debian_kivypie.py
@@ -30,7 +30,7 @@ packages=[
     { 'fileset': [ '/usr/local/lib/python2.7/dist-packages/kivy/*' ],  
       'pkg_name': 'python2-kivypie',
       'pkg_version': build_kivypie.__version__,
-      'pkg_depends': 'python2.7 libsdl2-2.0-0, libsdl2-image-2.0-0, libsdl2-mixer-2.0-0, '\
+      'pkg_depends': 'python2.7, libsdl2-2.0-0, libsdl2-image-2.0-0, libsdl2-mixer-2.0-0, '\
                      'libsdl2-ttf-2.0-0, python-beautifulsoup',
       'pkg_description': 'Python2 Kivy libraries for the RaspberryPI'
     },
@@ -39,7 +39,7 @@ packages=[
     { 'fileset': [ '/usr/local/lib/python3.4/dist-packages/kivy/*' ],  
       'pkg_name': 'python3-kivypie',
       'pkg_version': build_kivypie.__version__,
-      'pkg_depends': 'python3.4 libsdl2-2.0-0, libsdl2-image-2.0-0, libsdl2-mixer-2.0-0, '\
+      'pkg_depends': 'python3.4, libsdl2-2.0-0, libsdl2-image-2.0-0, libsdl2-mixer-2.0-0, '\
                      'libsdl2-ttf-2.0-0, python3-bs4',
       'pkg_description': 'Python3 Kivy libraries for the RaspberryPI'
     },

--- a/debian_kivypie.py
+++ b/debian_kivypie.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+#  Simple script to collect KivyPie binaries into Debian packages.
+#
+#  Two versions are generated, one for python2 and python3.
+#  The output files are: python2-kivypie.deb and python3-kivypie.deb
+#
+#  NOTE: Initial version with bare dependencies, likely more are missing.
+#
+
+import os
+import sys
+import build_kivypie
+
+# This is Debian control file
+debian_control='''
+Maintainer: Albert Casals <skarbat@gmail.com>
+Section: graphics
+Package: {pkg_name}
+Version: {pkg_version}
+Architecture: armhf
+Depends: debconf (>= 0.5.00), {pkg_depends}
+Priority: optional
+Description: {pkg_description}
+'''
+
+packages=[
+
+    # Kivypie debian package for Python2
+    { 'fileset': [ '/usr/local/lib/python2.7/dist-packages/kivy/*' ],  
+      'pkg_name': 'python2-kivypie',
+      'pkg_version': build_kivypie.__version__,
+      'pkg_depends': 'python2.7 libsdl2-2.0-0, libsdl2-image-2.0-0, libsdl2-mixer-2.0-0, '\
+                     'libsdl2-ttf-2.0-0, python-beautifulsoup',
+      'pkg_description': 'Python2 Kivy libraries for the RaspberryPI'
+    },
+
+    # Kivypie debian package for Python3
+    { 'fileset': [ '/usr/local/lib/python3.4/dist-packages/kivy/*' ],  
+      'pkg_name': 'python3-kivypie',
+      'pkg_version': build_kivypie.__version__,
+      'pkg_depends': 'python3.4 libsdl2-2.0-0, libsdl2-image-2.0-0, libsdl2-mixer-2.0-0, '\
+                     'libsdl2-ttf-2.0-0, python3-bs4',
+      'pkg_description': 'Python3 Kivy libraries for the RaspberryPI'
+    },
+
+    # Kivypie debian package for official Kivy examples
+    { 'fileset': [ '/usr/local/share/kivy-examples/*' ],  
+      'pkg_name': 'python-kivypie-examples',
+      'pkg_version': build_kivypie.__version__,
+      'pkg_depends': 'python2-kivypie | python3-kivypie',
+      'pkg_description': 'Python Kivy examples for the RaspberryPI'
+    }
+]
+
+
+
+if __name__ == '__main__':
+
+    help='debianize-kivypie.py <rootfs path>'
+    pkgsdir='pkgs'
+
+    if len(sys.argv) < 2:
+        print help
+        sys.exit(1)
+    else:
+        rootfs=sys.argv[1]
+
+    if not os.path.isdir(rootfs):
+        print 'cannot access', rootfs
+        sys.exit(1)
+
+    for pkg in packages:
+        # allocate a versioned directory for the package
+        versioned_pkg_name = '{}_{}'.format(pkg['pkg_name'], build_kivypie.__version__)
+        pkg_target=os.path.join(pkgsdir, versioned_pkg_name)
+        print 'Processing package {}... into {}'.format(versioned_pkg_name, pkg_target)
+
+        if not os.path.isdir(pkg_target):
+            os.makedirs(pkg_target)
+
+        # populate the files for packaging
+        for f in pkg['fileset']:
+            source_files='{}/{}'.format(rootfs, f)
+            target_tree='{}/{}'.format(pkg_target, os.path.dirname(f))
+            if not os.path.isdir(target_tree):
+                os.makedirs(target_tree)
+
+            print 'Extracting {}...'.format(source_files)
+            os.system('cp -rP {} {}'.format(source_files, target_tree))
+
+        # create a DEBIAN control file for building
+        debian_dir=os.path.join(pkg_target, 'DEBIAN')
+        if not os.path.exists(debian_dir):
+            os.makedirs(debian_dir)
+        with open(os.path.join(debian_dir, 'control'), 'w') as control_file:
+            control_file.writelines(debian_control.format(**pkg))
+
+        # run the magic
+        rc=os.system('dpkg-deb --build {}'.format(pkg_target))
+        if not rc:
+            print 'Package {} created correctly'.format(pkg_target)
+        else:
+            print 'WARNING: Error creating package {}'.format(pkg_target)

--- a/test_image.sh
+++ b/test_image.sh
@@ -13,7 +13,7 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 
-dispmanx=`xsysroot -p $xprofile -x "which dispman_vncserver"`
+dispmanx=`xsysroot -p $xprofile -x "which dispmanx_vncserver"`
 if [ "$?" != "0" ]; then
     echo "dispman_vncserver - FAILED"
 else

--- a/xsysroot.conf
+++ b/xsysroot.conf
@@ -6,7 +6,7 @@
      "boot_part" : "p1",
      "sysboot" : "/tmp/kivypie_boot",
      "tmp" : "~/xtmp",
-     "backing_image": "~/osimages/pipaos-lulo-xgui-4.3.img.gz",
+     "backing_image": "~/osimages/pipaos-lulo-xgui-4.6.img.gz",
      "qcow_image": "~/osimages/kivypie.qcow",
      "qcow_size": "3.5G"
   }


### PR DESCRIPTION
Builds the Kivy framework for Python 2 and 3.
Then it generates separate Debian packages for both Pythons, and official examples.
Integrated into the build process.
